### PR TITLE
Fix sorting algorithm slug names

### DIFF
--- a/src/main/java/fr/charles/algovisualizer/services/SortingService.java
+++ b/src/main/java/fr/charles/algovisualizer/services/SortingService.java
@@ -24,11 +24,15 @@ public class SortingService {
     }
 
     private void registerAlgorithm(SortingAlgorithm algorithm) {
-        algorithms.put(algorithm.getName().toLowerCase(Locale.ROOT), algorithm);
+        algorithms.put(slugify(algorithm.getName()), algorithm);
+    }
+
+    private String slugify(String name) {
+        return name.toLowerCase(Locale.ROOT).replaceAll("\\s+", "-");
     }
 
     public List<int[]> sort(String algorithmName, int[] array) {
-        SortingAlgorithm algorithm = algorithms.get(algorithmName.toLowerCase(Locale.ROOT));
+        SortingAlgorithm algorithm = algorithms.get(slugify(algorithmName));
         if (algorithm == null) {
             throw new IllegalArgumentException("Algorithme inconnu : " + algorithmName);
         }


### PR DESCRIPTION
## Summary
- handle algorithm slugs without spaces to make REST paths usable

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845edac4c5c8329ab79f6fb2c7253a1