### PR TITLE
Fix algorithm values and dynamic select

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -23,9 +23,9 @@
 <h1>Sorting Visualizer</h1>
 <div id="controls">
     <select id="algorithm">
-        <option value="bubble">Bubble Sort</option>
-        <option value="quick">Quick Sort</option>
-        <option value="insertion">Insertion Sort</option>
+        <option value="bubble-sort">Bubble Sort</option>
+        <option value="quick-sort">Quick Sort</option>
+        <option value="insertion-sort">Insertion Sort</option>
     </select>
     <button onclick="startSorting()">Start Sorting</button>
 </div>

--- a/src/main/resources/static/visualizer.js
+++ b/src/main/resources/static/visualizer.js
@@ -23,3 +23,25 @@ async function startSorting() {
     // Démarrer la visualisation
     visualizeSorting(steps);
 }
+
+async function loadAlgorithms() {
+    try {
+        const response = await fetch('/api/sort/algorithms');
+        if (!response.ok) {
+            throw new Error('Failed to load algorithms');
+        }
+        const algorithms = await response.json();
+        const select = document.getElementById('algorithm');
+        select.innerHTML = '';
+        Object.keys(algorithms).forEach(key => {
+            const option = document.createElement('option');
+            option.value = key;
+            option.textContent = algorithms[key];
+            select.appendChild(option);
+        });
+    } catch (e) {
+        console.error('Error loading algorithms', e);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', loadAlgorithms);


### PR DESCRIPTION
## Summary
- use slugified algorithm values in `index.html`
- fetch available algorithms from `/api/sort/algorithms` and populate the dropdown on page load

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845f04bb0b88329bf2075b44771705e