### PR TITLE
Add sorting visualization with canvas

### DIFF
--- a/src/main/resources/static/visualizer.js
+++ b/src/main/resources/static/visualizer.js
@@ -23,3 +23,40 @@ async function startSorting() {
     // Démarrer la visualisation
     visualizeSorting(steps);
 }
+
+function visualizeSorting(steps) {
+    const canvas = document.getElementById("canvas");
+    const ctx = canvas.getContext("2d");
+
+    const width = canvas.width;
+    const height = canvas.height;
+
+    // Déterminer la valeur maximale pour mettre à l'échelle les barres
+    const allValues = steps.flat();
+    const maxVal = Math.max(...allValues);
+
+    let index = 0;
+
+    function draw() {
+        if (index >= steps.length) {
+            return;
+        }
+
+        ctx.clearRect(0, 0, width, height);
+
+        const array = steps[index];
+        const barWidth = width / array.length;
+
+        for (let i = 0; i < array.length; i++) {
+            const value = array[i];
+            const barHeight = (value / maxVal) * height;
+            ctx.fillStyle = "steelblue";
+            ctx.fillRect(i * barWidth, height - barHeight, barWidth - 1, barHeight);
+        }
+
+        index++;
+        requestAnimationFrame(draw);
+    }
+
+    draw();
+}


### PR DESCRIPTION
## Summary
- implement `visualizeSorting` to animate sorting steps

## Testing
- `sh mvnw -q test` *(fails: mvnw: 109: cannot open mvnw/.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6845f0539c7c8329817cb77ae5a3a8fc