### PR TITLE
Add array size option

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -27,6 +27,8 @@
         <option value="quick">Quick Sort</option>
         <option value="insertion">Insertion Sort</option>
     </select>
+    <label for="arraySize">Items:</label>
+    <input type="number" id="arraySize" value="50" min="1" style="width:60px;" />
     <button onclick="startSorting()">Start Sorting</button>
 </div>
 <canvas id="canvas" width="800" height="400"></canvas>

--- a/src/main/resources/static/visualizer.js
+++ b/src/main/resources/static/visualizer.js
@@ -1,8 +1,9 @@
 async function startSorting() {
     const algorithm = document.getElementById("algorithm").value;
+    const size = parseInt(document.getElementById("arraySize").value, 10) || 50;
 
     // Générer un tableau aléatoire
-    const array = Array.from({ length: 50 }, () => Math.floor(Math.random() * 300));
+    const array = Array.from({ length: size }, () => Math.floor(Math.random() * 300));
     console.log("Tableau envoyé :", array); // Log pour vérifier le contenu
 
     // Envoyer une requête à l'API pour récupérer les étapes du tri


### PR DESCRIPTION
## Summary
- add a numeric field in the UI to control the number of generated items
- use that value in `startSorting()` instead of always generating 50 items

## Testing
- `./mvnw test` *(fails: Could not download Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845f0545c6883298fd5551797f16632