### PR TITLE
Add caching headers and compression

### DIFF
--- a/src/main/java/fr/charles/algovisualizer/config/WebConfig.java
+++ b/src/main/java/fr/charles/algovisualizer/config/WebConfig.java
@@ -1,0 +1,29 @@
+package fr.charles.algovisualizer.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.HandlerInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.time.Duration;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private static class CacheControlInterceptor implements HandlerInterceptor {
+        @Override
+        public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+            if (!response.containsHeader("Cache-Control")) {
+                response.setHeader("Cache-Control", "max-age=" + Duration.ofHours(1).toSeconds());
+            }
+            return true;
+        }
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new CacheControlInterceptor());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=demo
+# Enable response compression
+server.compression.enabled=true
+server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css
+server.compression.min-response-size=1024
+
+# Cache control for static resources
+spring.web.resources.cache.cachecontrol.max-age=3600
+spring.web.resources.cache.cachecontrol.cache-public=true
+spring.web.resources.cache.cachecontrol.must-revalidate=true


### PR DESCRIPTION
## Summary
- configure global `Cache-Control` header with `WebConfig`
- enable gzip compression and static resource caching in `application.properties`

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845f05917e88329a16b6fcc9e6c960b